### PR TITLE
Add support for CSS `@import` directive

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
     },
   },
   coverageDirectory: "test/coverage",
-  collectCoverageFrom: ["src/**/*.ts"],
+  collectCoverageFrom: ["src/**/*.ts", "!src/@types/**/*"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  collectCoverage: true,
   globals: {
     "ts-jest": {
       tsconfig: "tsconfig-mjs.json",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.1",
+    "postcss": "8.3.6",
+    "postcss-import": "14.0.2",
     "tslib": "^2.3.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "repository": "https://github.com/skarab42/rollup-plugin-css-export.git",
   "scripts": {
     "test": "jest",
+    "test:coverage": "yarn test --collect-coverage",
     "clean": "rimraf dist",
     "prepublishOnly": "yarn build",
     "dev": "tsc -w -p tsconfig-mjs.json",

--- a/src/@types/postcss-import/index.d.ts
+++ b/src/@types/postcss-import/index.d.ts
@@ -1,0 +1,26 @@
+// Based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2cbb6390a8c84fef9ec42dac7d09e8b98a3221f9/types/postcss-import/index.d.ts
+// Simplified & updated for recent versions of postcss types.
+declare module "postcss-import" {
+  import { AcceptedPlugin, PluginCreator } from "postcss";
+
+  declare interface AtImportOptions {
+    root?: string;
+    path?: string | string[];
+    plugins?: AcceptedPlugin[];
+    resolve?: (
+      id: string,
+      basedir: string,
+      importOptions: AtImportOptions
+    ) => string | string[] | Promise<string | string[]>;
+    load?: (
+      filename: string,
+      importOptions: AtImportOptions
+    ) => string | Promise<string>;
+    skipDuplicates?: boolean;
+    addModulesDirectories?: string[];
+  }
+
+  function atImport(options?: AtImportOptions): PluginCreator<AtImportOptions>;
+
+  export = atImport;
+}

--- a/test/fixtures/import/basic.css
+++ b/test/fixtures/import/basic.css
@@ -1,0 +1,6 @@
+@import "../lib/utils.css";
+
+/* basic.css */
+body {
+  background-color: purple;
+}

--- a/test/fixtures/import/basic.js
+++ b/test/fixtures/import/basic.js
@@ -1,0 +1,3 @@
+import "./basic.css";
+
+console.log("basic.js");

--- a/test/fixtures/import/duplicate.css
+++ b/test/fixtures/import/duplicate.css
@@ -1,0 +1,7 @@
+@import "../lib/reset.css";
+@import "../lib/layout.css";
+
+/* duplicate.css */
+body {
+  background-color: aqua;
+}

--- a/test/fixtures/import/duplicate.js
+++ b/test/fixtures/import/duplicate.js
@@ -1,0 +1,3 @@
+import "./duplicate.css";
+
+console.log("duplicate.js");

--- a/test/fixtures/import/invalid.css
+++ b/test/fixtures/import/invalid.css
@@ -1,0 +1,6 @@
+@import "what.css";
+
+/* invalid.css */
+body {
+  background-color: blue;
+}

--- a/test/fixtures/import/invalid.js
+++ b/test/fixtures/import/invalid.js
@@ -1,0 +1,3 @@
+import "./invalid.css";
+
+console.log("invalid.js");

--- a/test/fixtures/import/multiple.css
+++ b/test/fixtures/import/multiple.css
@@ -1,0 +1,7 @@
+@import "../lib/utils.css";
+@import "../red.css";
+
+/* multiple.css */
+body {
+  background-color: fuchsia;
+}

--- a/test/fixtures/import/multiple.js
+++ b/test/fixtures/import/multiple.js
@@ -1,0 +1,3 @@
+import "./multiple.css";
+
+console.log("multiple.js");

--- a/test/fixtures/import/nested.css
+++ b/test/fixtures/import/nested.css
@@ -1,0 +1,6 @@
+@import "../lib/fonts.css";
+
+/* nested.css */
+body {
+  background-color: yellow;
+}

--- a/test/fixtures/import/nested.js
+++ b/test/fixtures/import/nested.js
@@ -1,0 +1,3 @@
+import "./nested.css";
+
+console.log("nested.js");

--- a/test/fixtures/lib/fonts.css
+++ b/test/fixtures/lib/fonts.css
@@ -1,0 +1,6 @@
+@import "utils.css";
+
+/* fonts.css */
+body {
+  font-family: sans-serif;
+}

--- a/test/fixtures/lib/layout.css
+++ b/test/fixtures/lib/layout.css
@@ -1,0 +1,6 @@
+@import "reset.css";
+
+/* layout.css */
+section {
+  margin: 0;
+}

--- a/test/fixtures/lib/utils.css
+++ b/test/fixtures/lib/utils.css
@@ -1,0 +1,4 @@
+/* utils.css */
+h1.greenTitle {
+  color: green;
+}

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -22,11 +22,23 @@ const defaultOutputOptions = {
   assetFileNames: "assets/[name].[ext]",
 };
 
-function expectTree(fixtures: string[], outputs: string[]) {
+function expectTree(outputs: string[]) {
   expect(tempGlob()).toEqual(expect.arrayContaining(outputs));
+}
+
+function expectTreeAndContent(fixtures: string[], outputs: string[]) {
+  expectTree(outputs);
 
   outputs.forEach((output, index) => {
-    expect(readFile(fixtures[index] as string)).toEqual(readFile(output));
+    const fixture = fixtures[index];
+
+    if (!fixture) {
+      throw new Error(
+        `Missing fixture(s) for output '${output}' at index ${index}.`
+      );
+    }
+
+    expect(readFile(fixture)).toEqual(readFile(output));
   });
 }
 
@@ -52,11 +64,11 @@ function testPlugin(options: TestPluginOptions): Plugin {
   };
 }
 
-describe("rollup-plugin-css-export", () => {
-  afterEach(() => {
-    rimraf.sync(tempDir);
-  });
+afterEach(() => {
+  rimraf.sync(tempDir);
+});
 
+describe("Basic CSS", () => {
   it("should output red.js assets", async () => {
     const fixtures: string[] = [
       "test/fixtures/red.css",
@@ -74,7 +86,7 @@ describe("rollup-plugin-css-export", () => {
 
     await bundle.write(defaultOutputOptions);
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
   });
 
   it("should output purple.js assets", async () => {
@@ -96,7 +108,7 @@ describe("rollup-plugin-css-export", () => {
 
     await bundle.write(defaultOutputOptions);
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
   });
 
   it("should output purple.js assets preserving paths", async () => {
@@ -121,7 +133,7 @@ describe("rollup-plugin-css-export", () => {
       preserveModules: true,
     });
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
   });
 
   it("should output purple.js assets preserving paths from `test` dir", async () => {
@@ -147,7 +159,7 @@ describe("rollup-plugin-css-export", () => {
       preserveModulesRoot: "test",
     });
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
   });
 
   it("should export entry metadata", async () => {
@@ -181,7 +193,7 @@ describe("rollup-plugin-css-export", () => {
 
     await bundle.write(defaultOutputOptions);
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
     expect(metadata).toStrictEqual(expectedMetadata);
   });
 
@@ -210,7 +222,7 @@ describe("rollup-plugin-css-export", () => {
 
     await bundle.write(defaultOutputOptions);
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
     expect(metadata).toStrictEqual(expectedMetadata);
   });
 
@@ -225,6 +237,100 @@ describe("rollup-plugin-css-export", () => {
 
     await bundle.write(defaultOutputOptions);
 
-    expectTree(fixtures, outputs);
+    expectTreeAndContent(fixtures, outputs);
+  });
+});
+
+describe("CSS with @import directive(s)", () => {
+  it.each([
+    {
+      name: "should inline a single @import directive",
+      fixture: "basic",
+      expected: `/* utils.css */
+h1.greenTitle {
+  color: green;
+}
+/* basic.css */
+body {
+  background-color: purple;
+}
+`,
+    },
+    {
+      name: "should inline multiple @import directives",
+      fixture: "multiple",
+      expected: `/* utils.css */
+h1.greenTitle {
+  color: green;
+}
+/* red.css */
+body {
+  background-color: red;
+}
+/* multiple.css */
+body {
+  background-color: fuchsia;
+}
+`,
+    },
+    {
+      name: "should inline nested @import directives",
+      fixture: "nested",
+      expected: `/* utils.css */
+h1.greenTitle {
+  color: green;
+}
+/* fonts.css */
+body {
+  font-family: sans-serif;
+}
+/* nested.css */
+body {
+  background-color: yellow;
+}
+`,
+    },
+    {
+      name: "should skip similar @import directives",
+      fixture: "duplicate",
+      expected: `* {
+  margin: 0;
+  padding: 0;
+}
+/* layout.css */
+section {
+  margin: 0;
+}
+/* duplicate.css */
+body {
+  background-color: aqua;
+}
+`,
+    },
+  ])("$name", async ({ fixture, expected }) => {
+    const bundle = await rollup({
+      input: `test/fixtures/import/${fixture}.js`,
+      plugins: [css()],
+    });
+
+    await bundle.write(defaultOutputOptions);
+
+    const outputPath = `test/temp/assets/${fixture}.css`;
+
+    expectTree([outputPath]);
+    expect(readFile(outputPath)).toEqual(expected);
+  });
+
+  it("should gracefully fail on invalid @import directive(s) and report the associated CSS file", async () => {
+    const bundle = await rollup({
+      input: `test/fixtures/import/invalid.js`,
+      plugins: [css()],
+    });
+
+    await expect(
+      bundle.write(defaultOutputOptions)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Something went wrong when inlining an @import directive in 'invalid.css'."`
+    );
   });
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig-mjs.json",
+  "include": ["../src/**/*.ts", "../test/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,6 +2023,11 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+nanoid@^3.1.23:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
+  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2145,6 +2150,11 @@ picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
+pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -2158,6 +2168,29 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+postcss-import@14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-14.0.2.tgz#60eff77e6be92e7b67fe469ec797d9424cae1aa1"
+  integrity sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
+postcss-value-parser@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
+  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
+postcss@8.3.6:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.6.tgz#2730dd76a97969f37f53b9a6096197be311cc4ea"
+  integrity sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2197,6 +2230,13 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
+  dependencies:
+    pify "^2.3.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -2214,7 +2254,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.19.0, resolve@^1.20.0:
+resolve@^1.1.7, resolve@^1.19.0, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -2291,6 +2331,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-support@^0.5.6:
   version "0.5.19"


### PR DESCRIPTION
We did not really discuss this so feel free to ignore & close this PR without merging it and no questions asked if you don't want this feature, don't like the implementation or any other reason.

---

First, some changes not really related to the new feature but I didn't feel like opening 2 small PRs for this considering that the project is relatively new.

### Coverage

I removed the `collectCoverage: true` option from the `jest.config.js` as [Istanbul](https://istanbul.js.org/) slows down the tests and it gets really annoying when using Jest in watch mode to have this output every time. Instead, I added a `yarn test:coverage` scripts to the `package.json` file.

Note: if you're interested, it's also very common to chain this command like `yarn test --collect-coverage && open test/coverage/lcov-report/index.html` with the [`open` package](https://www.npmjs.com/package/open) so that the HTML report is automatically opened in your browser when you run `yarn test:coverage`.

### Test `tsconfig.json`

Visual Studio Code was not providing any IntelliSense or error reporting in test files as they were not part of the `include` property of the `tsconfig.json` files. The only way to get proper error reporting was actually to run the tests. I also believe this is what led to code like this `readFile(fixtures[index] as string)`.

To fix this issue, I added a new `tsconfig.json` file in the `test` directory extending the default one and overriding the `include` property.

---

## [`@import`](https://developer.mozilla.org/en-US/docs/Web/CSS/@import) CSS directive support

The first point to mention is that the modifications in this PR do not change at all the output code or behavior for code not using this directive.

This is a bit of an edge case for this plugin, and in the "bundler" world. The most common expectation when using this directive is to use a [PostCSS](https://github.com/postcss/postcss) plugin for your bundler with a [PostCSS plugin like `postcss-import`](https://github.com/postcss/postcss-import) to transform `@import` rules by inlining content.

At the moment, the `rollup-plugin-css-export` plugin doesn't do anything related to this directive which can **lead in very basic scenarios to missing CSS**.

To avoid this issue, this PR add basic support for this directive by providing the same inlining feature if an `@import` directive is used.

The implementation is fairly simple: as there is no point in reinventing the wheel here, we use [PostCSS](https://github.com/postcss/postcss) to parse the CSS code into an AST with the PostCSS plugin [`postcss-import`](https://github.com/postcss/postcss-import) to transform these directives and inlining the imported content **only if any import was used** (no other transform are used so the code is not modified in any other way just like when not using this plugin and this directive).

I added tests for most common scenarios. I decided to inline the expected CSS outputs in the tests as it's not that much CSS code. We could manually replace the `@import` directives, resolve the CSS imported files, concatenate the content and at this point, we're basically recreating a bad version of  [`postcss-import`](https://github.com/postcss/postcss-import). 

The options of [`postcss-import`](https://github.com/postcss/postcss-import#options) are not exposed (yet) to the end-user through the plugin as it's a bit of an edge case, but if it's ever needed, they could also be exposed.

Like I mentioned at the beginning, if you don't want to support this "fallback", don't like the implementation or for any other reasons, feel free to ignore & close this PR without merging it, no questions asked.